### PR TITLE
Changed nodejs specification from nodejs4.3 to nodejs8.10

### DIFF
--- a/forwarder.template
+++ b/forwarder.template
@@ -80,7 +80,7 @@ Resources:
                     }
                 });
             }
-        Runtime: nodejs4.3
+        Runtime: nodejs8.10
     SNSEmailReceiveTopic:
       Type: AWS::SNS::Topic
       Properties:


### PR DESCRIPTION
AWS CloudFormation no longer works with nodejs4.3. I updated the specification to nodejs8.10 and was able to get the stack to build successfully.